### PR TITLE
fix: 无法从 admin 页面注销

### DIFF
--- a/contest/contest/settings.py
+++ b/contest/contest/settings.py
@@ -143,4 +143,5 @@ AUTHENTICATION_BACKENDS = [
 CAS_SERVER_URL = "https://login.bit.edu.cn/devcas/"
 CAS_VERSION = "2"
 CAS_LOGIN_URL_NAME = LOGIN_URL
+CAS_LOGOUT_URL_NAME = "logout"  # 会用于 Django 提供的模板，如 admin
 CAS_REDIRECT_URL = LOGIN_REDIRECT_URL


### PR DESCRIPTION
NoReverseMatch at /admin/logout/

Reverse for 'cas_ng_logout' not found. 'cas_ng_logout' is not a valid view function or pattern name.

原因：在`contest/contest/urls.py`中，`name="logout"`，不是默认的`cas_ng_logout`，因此需要设置`CAS_LOGOUT_URL_NAME`。
