### PR TITLE
build(deps): bump actions/upload-artifact and actions/download-artifact from 3 to 4

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -64,7 +64,7 @@ jobs:
     - run: just build-theme
     - run: just build-js
     - name: Upload front-end artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: front-end
         path: |
@@ -140,7 +140,7 @@ jobs:
     # Install and update
     - run: just update-dependencies
     - name: Download front-end artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: front-end
         path: contest/


### PR DESCRIPTION
> Uploads and downloads must use the same major actions versions.

Replaces #135 and #137
